### PR TITLE
Respect LEMONADE_CTX_SIZE for context window reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The extension connects to `http://localhost:8000/api/v1` by default. You can cha
 3. Entering your custom Lemonade server URL
 4. Optionally, entering your API key (if your server has `LEMONADE_API_KEY` configured)
 
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LEMONADE_CTX_SIZE` | `128000` | Context window size (in tokens) reported to VS Code. Set this to match the `--ctx-size` value used when starting Lemonade so the model picker displays the correct context limits. For example, `LEMONADE_CTX_SIZE=262144` for a 256 k context window. |
+
+> **Tip:** Launch VS Code from a terminal where `LEMONADE_CTX_SIZE` is already set, or add it to your system/user environment variables so it is always picked up.
+
 ## Support & License
 * Open issues: https://github.com/lemonade-sdk/lemonade/issues
 * License: MIT License Copyright (c) 2025 Lemonade

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lemonade-sdk",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lemonade-sdk",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/lemonade-sdk/lemonade"
 	},
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"engines": {
 		"vscode": "^1.104.0"
 	},

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -18,6 +18,22 @@ const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_API_KEY = "lemonade";
 
 /**
+ * Resolve the context length to use. Reads LEMONADE_CTX_SIZE from the
+ * environment; falls back to DEFAULT_CONTEXT_LENGTH when the variable is
+ * absent or not a positive integer.
+ */
+function resolveContextLength(): number {
+	const raw = process.env["LEMONADE_CTX_SIZE"];
+	if (raw) {
+		const parsed = parseInt(raw, 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+	return DEFAULT_CONTEXT_LENGTH;
+}
+
+/**
  * VS Code Chat provider backed by Lemonade local LLM server.
  */
 export class LemonadeChatModelProvider implements LanguageModelChatProvider {
@@ -106,7 +122,7 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 		}
 
 		const maxOutput = DEFAULT_MAX_OUTPUT_TOKENS;
-		const maxInput = Math.max(1, DEFAULT_CONTEXT_LENGTH - maxOutput);
+		const maxInput = Math.max(1, resolveContextLength() - maxOutput);
 
 		const infos: LanguageModelChatInformation[] = models.map(model => ({
 			id: model.id,


### PR DESCRIPTION
The extension previously hardcoded the context window to 128 k tokens regardless of how Lemonade was started. Users running the server with a larger context (e.g. --ctx-size 262144) would still see 128 k reported in the VS Code model picker, causing the input token limit to be unnecessarily capped.

The fix reads the LEMONADE_CTX_SIZE environment variable at runtime and uses its value as the context length. If the variable is absent or invalid, the original 128 k default is preserved. The README is updated to document the variable and how to set it.