### PR TITLE
Support multiple Lemonade endpoints

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,14 @@ export function activate(context: vscode.ExtensionContext) {
 	const ext = vscode.extensions.getExtension("lemonade-sdk.lemonade-sdk");
 	const extVersion = ext?.packageJSON?.version ?? "unknown";
 	const vscodeVersion = vscode.version;
+	// Keep UA minimal: only extension version and VS Code version
 	const ua = `lemonade-sdk/${extVersion} VSCode/${vscodeVersion}`;
 
 	const provider = new LemonadeChatModelProvider(context.secrets, ua);
+	// Register the Lemonade provider under the vendor id used in package.json
 	vscode.lm.registerLanguageModelChatProvider("lemonade", provider);
 
+	// Management command to configure server settings
 	context.subscriptions.push(
 		vscode.commands.registerCommand("lemonade.manage", async () => {
 			await manageEndpoints(context.secrets, provider);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,7 @@ async function addEndpointFlow(
 
 	const url = await vscode.window.showInputBox({
 		title: "Add Lemonade Endpoint (2/3) — URL",
-		prompt: "Enter the server URL (e.g. http://192.168.1.17:8000/api/v1)",
+		prompt: "Enter the server URL (e.g. http://fqdn.local:13305/api/v1)",
 		value: "http://",
 		ignoreFocusOut: true,
 		validateInput: isValidUrl,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,66 +1,205 @@
 import * as vscode from "vscode";
 import { LemonadeChatModelProvider } from "./provider";
+import type { LemonadeEndpoint } from "./types";
+
+const ENDPOINTS_SECRET_KEY = "lemonade.endpoints";
 
 export function activate(context: vscode.ExtensionContext) {
 	const ext = vscode.extensions.getExtension("lemonade-sdk.lemonade-sdk");
 	const extVersion = ext?.packageJSON?.version ?? "unknown";
 	const vscodeVersion = vscode.version;
-	// Keep UA minimal: only extension version and VS Code version
 	const ua = `lemonade-sdk/${extVersion} VSCode/${vscodeVersion}`;
 
 	const provider = new LemonadeChatModelProvider(context.secrets, ua);
-	// Register the Lemonade provider under the vendor id used in package.json
 	vscode.lm.registerLanguageModelChatProvider("lemonade", provider);
 
-	// Management command to configure server settings
 	context.subscriptions.push(
 		vscode.commands.registerCommand("lemonade.manage", async () => {
-			const existingUrl = await context.secrets.get("lemonade.serverUrl");
-			const existingApiKey = await context.secrets.get("lemonade.apiKey");
-			const defaultUrl = "http://localhost:13305/api/v1";
-
-			// Step 1: Server URL configuration
-			const serverUrl = await vscode.window.showInputBox({
-				title: "Lemonade Server URL",
-				prompt: existingUrl ? "Update your Lemonade server URL" : "Enter your Lemonade server URL",
-				ignoreFocusOut: true,
-				value: existingUrl ?? defaultUrl,
-			});
-			if (serverUrl === undefined) {
-				return; // user canceled
-			}
-			if (!serverUrl.trim()) {
-				await context.secrets.delete("lemonade.serverUrl");
-				vscode.window.showInformationMessage("Lemonade server URL reset to default.");
-				return;
-			}
-			await context.secrets.store("lemonade.serverUrl", serverUrl.trim());
-
-			// Step 2: API Key configuration (optional)
-			const apiKey = await vscode.window.showInputBox({
-				title: "Lemonade API Key",
-				prompt: existingApiKey
-					? "Update your Lemonade API key (leave empty to reset to default)"
-					: "Enter your Lemonade API key (optional, leave empty to use default)",
-				ignoreFocusOut: true,
-				password: true,
-				value: existingApiKey ?? "",
-				placeHolder: "Leave empty to use default API key",
-			});
-			if (apiKey === undefined) {
-				// User canceled, but URL was already saved
-				vscode.window.showInformationMessage("Lemonade server URL saved. API key unchanged.");
-				return;
-			}
-			if (!apiKey.trim()) {
-				await context.secrets.delete("lemonade.apiKey");
-				vscode.window.showInformationMessage("Lemonade settings saved. API key reset to default.");
-				return;
-			}
-			await context.secrets.store("lemonade.apiKey", apiKey.trim());
-			vscode.window.showInformationMessage("Lemonade settings saved.");
+			await manageEndpoints(context.secrets, provider);
 		})
 	);
 }
 
 export function deactivate() {}
+
+// ---------------------------------------------------------------------------
+// Endpoint management UI
+// ---------------------------------------------------------------------------
+
+async function saveEndpoints(secrets: vscode.SecretStorage, endpoints: LemonadeEndpoint[]): Promise<void> {
+	await secrets.store(ENDPOINTS_SECRET_KEY, JSON.stringify(endpoints));
+}
+
+async function manageEndpoints(secrets: vscode.SecretStorage, provider: LemonadeChatModelProvider): Promise<void> {
+	// Use the provider's own getEndpoints so migration also runs here
+	const endpoints = await provider.getEndpoints();
+
+	const ADD_LABEL = "$(add) Add endpoint";
+	const DONE_LABEL = "$(check) Done";
+
+	const items: vscode.QuickPickItem[] = [
+		...endpoints.map(ep => ({
+			label: ep.shortname,
+			description: ep.url,
+			detail: ep.apiKey ? "Custom API key configured" : undefined,
+		})),
+		{ label: "", kind: vscode.QuickPickItemKind.Separator },
+		{ label: ADD_LABEL },
+		{ label: DONE_LABEL },
+	];
+
+	const pick = await vscode.window.showQuickPick(items, {
+		title: "Lemonade Endpoints",
+		placeHolder: "Select an endpoint to edit/remove, or add a new one",
+	});
+
+	if (!pick || pick.label === DONE_LABEL) { return; }
+
+	if (pick.label === ADD_LABEL) {
+		const added = await addEndpointFlow(endpoints);
+		if (added) {
+			await saveEndpoints(secrets, endpoints);
+			vscode.window.showInformationMessage(`Endpoint "${added.shortname}" added.`);
+		}
+		return;
+	}
+
+	// Edit or remove an existing endpoint
+	const idx = endpoints.findIndex(ep => ep.shortname === pick.label);
+	if (idx === -1) { return; }
+
+	const action = await vscode.window.showQuickPick(
+		[
+			{ label: "$(edit) Edit", value: "edit" },
+			{ label: "$(trash) Remove", value: "remove" },
+			{ label: "$(close) Cancel", value: "cancel" },
+		],
+		{ title: `Endpoint: ${endpoints[idx].shortname}` }
+	);
+
+	if (!action || action.value === "cancel") { return; }
+
+	if (action.value === "remove") {
+		const confirm = await vscode.window.showWarningMessage(
+			`Remove endpoint "${endpoints[idx].shortname}"?`,
+			{ modal: true },
+			"Remove"
+		);
+		if (confirm !== "Remove") { return; }
+		endpoints.splice(idx, 1);
+		await saveEndpoints(secrets, endpoints);
+		vscode.window.showInformationMessage("Endpoint removed.");
+		return;
+	}
+
+	// Edit
+	const updated = await editEndpointFlow(endpoints[idx], endpoints, idx);
+	if (updated) {
+		endpoints[idx] = updated;
+		await saveEndpoints(secrets, endpoints);
+		vscode.window.showInformationMessage(`Endpoint "${updated.shortname}" updated.`);
+	}
+}
+
+function isValidShortname(value: string): string | undefined {
+	if (!value.trim()) { return "Shortname cannot be empty."; }
+	if (!/^[a-zA-Z0-9][a-zA-Z0-9\-_]*$/.test(value.trim())) {
+		return "Shortname must start with a letter or digit and contain only letters, digits, hyphens, and underscores.";
+	}
+	return undefined;
+}
+
+function isValidUrl(value: string): string | undefined {
+	if (!value.trim()) { return "URL cannot be empty."; }
+	if (!/^https?:\/\/.+/.test(value.trim())) { return "URL must start with http:// or https://"; }
+	return undefined;
+}
+
+async function addEndpointFlow(
+	existing: LemonadeEndpoint[]
+): Promise<LemonadeEndpoint | undefined> {
+	const shortname = await vscode.window.showInputBox({
+		title: "Add Lemonade Endpoint (1/3) — Shortname",
+		prompt: "Enter a unique shortname for this endpoint (e.g. node-17)",
+		ignoreFocusOut: true,
+		validateInput: (v) => {
+			const err = isValidShortname(v);
+			if (err) { return err; }
+			if (existing.some(ep => ep.shortname === v.trim())) {
+				return "A endpoint with this shortname already exists.";
+			}
+			return undefined;
+		},
+	});
+	if (shortname === undefined) { return undefined; }
+
+	const url = await vscode.window.showInputBox({
+		title: "Add Lemonade Endpoint (2/3) — URL",
+		prompt: "Enter the server URL (e.g. http://192.168.1.17:8000/api/v1)",
+		value: "http://",
+		ignoreFocusOut: true,
+		validateInput: isValidUrl,
+	});
+	if (url === undefined) { return undefined; }
+
+	const apiKey = await vscode.window.showInputBox({
+		title: "Add Lemonade Endpoint (3/3) — API Key (optional)",
+		prompt: "Enter the API key for this endpoint, or leave empty to use the default",
+		ignoreFocusOut: true,
+		password: true,
+		placeHolder: "Leave empty to use default API key",
+	});
+	if (apiKey === undefined) { return undefined; }
+
+	const ep: LemonadeEndpoint = {
+		shortname: shortname.trim(),
+		url: url.trim(),
+		...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+	};
+	existing.push(ep);
+	return ep;
+}
+
+async function editEndpointFlow(
+	ep: LemonadeEndpoint,
+	existing: LemonadeEndpoint[],
+	selfIdx: number
+): Promise<LemonadeEndpoint | undefined> {
+	const shortname = await vscode.window.showInputBox({
+		title: `Edit Endpoint "${ep.shortname}" (1/3) — Shortname`,
+		ignoreFocusOut: true,
+		value: ep.shortname,
+		validateInput: (v) => {
+			const err = isValidShortname(v);
+			if (err) { return err; }
+			if (existing.some((e, i) => i !== selfIdx && e.shortname === v.trim())) {
+				return "A endpoint with this shortname already exists.";
+			}
+			return undefined;
+		},
+	});
+	if (shortname === undefined) { return undefined; }
+
+	const url = await vscode.window.showInputBox({
+		title: `Edit Endpoint "${ep.shortname}" (2/3) — URL`,
+		ignoreFocusOut: true,
+		value: ep.url,
+		validateInput: isValidUrl,
+	});
+	if (url === undefined) { return undefined; }
+
+	const apiKey = await vscode.window.showInputBox({
+		title: `Edit Endpoint "${ep.shortname}" (3/3) — API Key (optional)`,
+		ignoreFocusOut: true,
+		password: true,
+		value: ep.apiKey ?? "",
+		placeHolder: "Leave empty to use default API key",
+	});
+	if (apiKey === undefined) { return undefined; }
+
+	return {
+		shortname: shortname.trim(),
+		url: url.trim(),
+		...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+	};
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -10,12 +10,13 @@ import {
 } from "vscode";
 
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
-import type { LemonadeModel, LemonadeModelsResponse } from "./types";
+import type { LemonadeEndpoint, LemonadeModel, LemonadeModelsResponse } from "./types";
 
 const DEFAULT_BASE_URL = "http://localhost:13305/api/v1";
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_API_KEY = "lemonade";
+const ENDPOINTS_SECRET_KEY = "lemonade.endpoints";
 
 /**
  * Resolve the context length to use. Reads LEMONADE_CTX_SIZE from the
@@ -100,43 +101,55 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	/**
-	 * Get the list of available language models contributed by this provider
-	 * @param options Options which specify the calling context of this function
-	 * @param token A cancellation token which signals if the user cancelled the request or not
-	 * @returns A promise that resolves to the list of available language models
+	 * Get the list of available language models contributed by this provider.
+	 * Fans out to all configured endpoints concurrently; failures on individual
+	 * endpoints are swallowed so healthy nodes still appear.
 	 */
 	async prepareLanguageModelChatInformation(
 		options: { silent: boolean },
 		_token: CancellationToken
 	): Promise<LanguageModelChatInformation[]> {
-		// Fetch available models from the Lemonade server
-		const models = await this.fetchModels();
-
-		if (models.length === 0) {
-			if (!options.silent) {
-				vscode.window.showWarningMessage(
-					"No models available from Lemonade server. Make sure Lemonade server is running. You can download it from lemonade-server.ai."
-				);
-			}
-			return [];
-		}
-
+		const endpoints = await this.getEndpoints();
 		const maxOutput = DEFAULT_MAX_OUTPUT_TOKENS;
 		const maxInput = Math.max(1, resolveContextLength() - maxOutput);
 
-		const infos: LanguageModelChatInformation[] = models.map(model => ({
-			id: model.id,
-			name: model.id,
-			tooltip: "Lemonade Local LLM",
-			family: "lemonade",
-			version: "1.0.0",
-			maxInputTokens: maxInput,
-			maxOutputTokens: maxOutput,
-			capabilities: {
-				toolCalling: true,
-				imageInput: false,
-			},
-		} satisfies LanguageModelChatInformation));
+		// Fetch models from all endpoints concurrently; ignore per-endpoint errors
+		const results = await Promise.all(
+			endpoints.map(async (ep) => {
+				try {
+					const models = await this.fetchModels(ep);
+					return { ep, models };
+				} catch {
+					return { ep, models: [] as LemonadeModel[] };
+				}
+			})
+		);
+
+		const infos: LanguageModelChatInformation[] = [];
+		for (const { ep, models } of results) {
+			for (const model of models) {
+				const id = `${ep.shortname}/${model.id}`;
+				infos.push({
+					id,
+					name: id,
+					tooltip: `Lemonade node: ${ep.url}`,
+					family: "lemonade",
+					version: "1.0.0",
+					maxInputTokens: maxInput,
+					maxOutputTokens: maxOutput,
+					capabilities: {
+						toolCalling: true,
+						imageInput: false,
+					},
+				} satisfies LanguageModelChatInformation);
+			}
+		}
+
+		if (infos.length === 0 && !options.silent) {
+			vscode.window.showWarningMessage(
+				"No models available from any Lemonade endpoint. Make sure at least one server is running. You can download it from lemonade-server.ai."
+			);
+		}
 
 		this._chatEndpoints = infos.map((info) => ({
 			model: info.id,
@@ -154,53 +167,62 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	/**
-	 * Get the configured server URL or return the default.
+	 * Return the list of configured endpoints. Falls back to a single default
+	 * endpoint when nothing has been configured yet, and migrates legacy
+	 * single-URL secrets on first access.
 	 */
-	private async getServerUrl(): Promise<string> {
-		const stored = await this.secrets.get("lemonade.serverUrl");
-		return stored || DEFAULT_BASE_URL;
-	}
-
-	/**
-	 * Get the configured API key or return the default.
-	 */
-	private async getApiKey(): Promise<string> {
-		const stored = await this.secrets.get("lemonade.apiKey");
-		return stored || DEFAULT_API_KEY;
-	}
-
-	/**
-	 * Fetch the list of available models from the Lemonade server.
-	 */
-	private async fetchModels(): Promise<LemonadeModel[]> {
-		const baseUrl = await this.getServerUrl();
-		const apiKey = await this.getApiKey();
-
-		try {
-			const response = await fetch(`${baseUrl}/models`, {
-				method: "GET",
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					"User-Agent": this.userAgent,
-				},
-			});
-
-			if (!response.ok) {
-				console.error("[Lemonade Model Provider] Failed to fetch models", {
-					status: response.status,
-					statusText: response.statusText,
-				});
-				throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`);
-			}
-
-			const data = (await response.json()) as LemonadeModelsResponse;
-			return data.data || [];
-		} catch (error) {
-			console.error("[Lemonade Model Provider] Error fetching models", error);
-			// Return empty array on error - this will result in no models being available
-			// which is better than crashing the extension
-			return [];
+	async getEndpoints(): Promise<LemonadeEndpoint[]> {
+		// Migration: promote legacy single-URL secrets to the new format
+		const legacyUrl = await this.secrets.get("lemonade.serverUrl");
+		if (legacyUrl) {
+			const legacyKey = await this.secrets.get("lemonade.apiKey");
+			const migrated: LemonadeEndpoint[] = [{
+				shortname: "default",
+				url: legacyUrl,
+				...(legacyKey ? { apiKey: legacyKey } : {}),
+			}];
+			await this.secrets.store(ENDPOINTS_SECRET_KEY, JSON.stringify(migrated));
+			await this.secrets.delete("lemonade.serverUrl");
+			await this.secrets.delete("lemonade.apiKey");
+			return migrated;
 		}
+
+		const stored = await this.secrets.get(ENDPOINTS_SECRET_KEY);
+		if (stored) {
+			try {
+				const parsed = JSON.parse(stored) as LemonadeEndpoint[];
+				if (Array.isArray(parsed) && parsed.length > 0) {
+					return parsed;
+				}
+			} catch {
+				// fall through to default
+			}
+		}
+
+		// No config yet — return built-in default so extension works out of the box
+		return [{ shortname: "default", url: DEFAULT_BASE_URL }];
+	}
+
+	/**
+	 * Fetch the list of available models from a single Lemonade endpoint.
+	 */
+	private async fetchModels(endpoint: LemonadeEndpoint): Promise<LemonadeModel[]> {
+		const apiKey = endpoint.apiKey || DEFAULT_API_KEY;
+
+		const response = await fetch(`${endpoint.url}/models`, {
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"User-Agent": this.userAgent,
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error(`[Lemonade] Failed to fetch models from ${endpoint.shortname}: ${response.status} ${response.statusText}`);
+		}
+
+		const data = (await response.json()) as LemonadeModelsResponse;
+		return data.data || [];
 	}
 
 	/**
@@ -245,8 +267,18 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 			},
 		};
 		try {
-			const baseUrl = await this.getServerUrl();
-			const apiKey = await this.getApiKey();
+			// Decode "<shortname>/<modelId>" from the model id
+			const slashIdx = model.id.indexOf("/");
+			const shortname = slashIdx >= 0 ? model.id.slice(0, slashIdx) : "default";
+			const realModelId = slashIdx >= 0 ? model.id.slice(slashIdx + 1) : model.id;
+
+			const endpoints = await this.getEndpoints();
+			const endpoint = endpoints.find(ep => ep.shortname === shortname)
+				?? endpoints[0]
+				?? { shortname: "default", url: DEFAULT_BASE_URL };
+
+			const baseUrl = endpoint.url;
+			const apiKey = endpoint.apiKey || DEFAULT_API_KEY;
 
             const openaiMessages = convertMessages(messages);
 
@@ -267,7 +299,7 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
             }
 
             requestBody = {
-                model: model.id,
+                model: realModelId,
                 messages: openaiMessages,
                 stream: true,
                 max_tokens: Math.min(options.modelOptions?.max_tokens || 4096, model.maxOutputTokens),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -204,7 +204,7 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	/**
-	 * Fetch the list of available models from a single Lemonade endpoint.
+	 * Fetch the list of available models from the Lemonade server.
 	 */
 	private async fetchModels(endpoint: LemonadeEndpoint): Promise<LemonadeModel[]> {
 		const apiKey = endpoint.apiKey || DEFAULT_API_KEY;

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { LemonadeChatModelProvider } from "../provider";
 import { convertMessages, convertTools, validateRequest, validateTools, tryParseJSONObject } from "../utils";
+import type { LemonadeEndpoint } from "../types";
 
 interface OpenAIToolCall {
 	id: string;
@@ -122,6 +123,99 @@ suite("Lemonade Chat Provider Extension", () => {
 				assert.ok(!errMsg.includes("API key"), "Should not fail due to API key");
 			}
 			assert.ok(threw, "Should throw due to connection error");
+		});
+
+		// ------------------------------------------------------------------
+		// Multi-endpoint tests
+		// ------------------------------------------------------------------
+
+		test("getEndpoints returns default when nothing stored", async () => {
+			const provider = new LemonadeChatModelProvider({
+				get: async () => undefined,
+				store: async () => {},
+				delete: async () => {},
+				onDidChange: (_listener: unknown) => ({ dispose() {} }),
+			} as unknown as vscode.SecretStorage, "test/test");
+
+			const endpoints = await provider.getEndpoints();
+			assert.ok(Array.isArray(endpoints) && endpoints.length === 1);
+			assert.equal(endpoints[0].shortname, "default");
+			assert.ok(endpoints[0].url.startsWith("http://localhost"));
+		});
+
+		test("getEndpoints migrates legacy serverUrl secret", async () => {
+			const store: Record<string, string> = {
+				"lemonade.serverUrl": "http://192.168.1.17:8000/api/v1",
+				"lemonade.apiKey": "mykey",
+			};
+			const deleted: string[] = [];
+			const provider = new LemonadeChatModelProvider({
+				get: async (k: string) => store[k],
+				store: async (k: string, v: string) => { store[k] = v; },
+				delete: async (k: string) => { deleted.push(k); delete store[k]; },
+				onDidChange: (_listener: unknown) => ({ dispose() {} }),
+			} as unknown as vscode.SecretStorage, "test/test");
+
+			const endpoints = await provider.getEndpoints();
+			assert.equal(endpoints.length, 1);
+			assert.equal(endpoints[0].shortname, "default");
+			assert.equal(endpoints[0].url, "http://192.168.1.17:8000/api/v1");
+			assert.equal(endpoints[0].apiKey, "mykey");
+			// Legacy keys must be deleted after migration
+			assert.ok(deleted.includes("lemonade.serverUrl"));
+			assert.ok(deleted.includes("lemonade.apiKey"));
+			// New key must be written
+			assert.ok(store["lemonade.endpoints"]);
+		});
+
+		test("getEndpoints reads multiple stored endpoints", async () => {
+			const endpoints: LemonadeEndpoint[] = [
+				{ shortname: "node-17", url: "http://192.168.1.17:8000/api/v1" },
+				{ shortname: "node-80", url: "http://192.168.1.80:8000/api/v1", apiKey: "secret" },
+			];
+			const provider = new LemonadeChatModelProvider({
+				get: async (k: string) => k === "lemonade.endpoints" ? JSON.stringify(endpoints) : undefined,
+				store: async () => {},
+				delete: async () => {},
+				onDidChange: (_listener: unknown) => ({ dispose() {} }),
+			} as unknown as vscode.SecretStorage, "test/test");
+
+			const result = await provider.getEndpoints();
+			assert.equal(result.length, 2);
+			assert.equal(result[0].shortname, "node-17");
+			assert.equal(result[1].shortname, "node-80");
+			assert.equal(result[1].apiKey, "secret");
+		});
+
+		test("prepareLanguageModelChatInformation prefixes model ids with shortname", async () => {
+			const endpoints: LemonadeEndpoint[] = [
+				{ shortname: "node-17", url: "http://192.168.1.17:8000/api/v1" },
+			];
+			// Mock fetch to return a single model
+			const originalFetch = global.fetch;
+			try {
+				(global as unknown as Record<string, unknown>).fetch = async () => ({
+					ok: true,
+					json: async () => ({ object: "list", data: [{ id: "Llama-3.2-3B", object: "model" }] }),
+				});
+
+				const provider = new LemonadeChatModelProvider({
+					get: async (k: string) => k === "lemonade.endpoints" ? JSON.stringify(endpoints) : undefined,
+					store: async () => {},
+					delete: async () => {},
+					onDidChange: (_listener: unknown) => ({ dispose() {} }),
+				} as unknown as vscode.SecretStorage, "test/test");
+
+				const infos = await provider.prepareLanguageModelChatInformation(
+					{ silent: true },
+					new vscode.CancellationTokenSource().token
+				);
+				assert.equal(infos.length, 1);
+				assert.equal(infos[0].id, "node-17/Llama-3.2-3B");
+				assert.equal(infos[0].name, "node-17/Llama-3.2-3B");
+			} finally {
+				(global as unknown as Record<string, unknown>).fetch = originalFetch;
+			}
 		});
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,15 @@ export interface ToolCallBuffer {
 }
 
 /**
+ * A configured Lemonade server endpoint with an optional shortname.
+ */
+export interface LemonadeEndpoint {
+	shortname: string;  // e.g. "node-17"
+	url: string;        // e.g. "http://192.168.1.17:8000/api/v1"
+	apiKey?: string;    // per-endpoint key; falls back to DEFAULT_API_KEY when absent
+}
+
+/**
  * Model entry from the /models endpoint
  */
 export interface LemonadeModel {


### PR DESCRIPTION
This code was entirely generated by a Mixture of Copilot Auto and Copilot Lemonade (Qwen3-Coder-Next-GGUF-UD-Q8_K_XL).

# Multiple Endpoints Support

This PR adds comprehensive support for multiple Lemonade server endpoints in the VS Code extension.

## Changes

### New Data Type

**`src/types.ts`**
- Added `LemonadeEndpoint` interface with `shortname`, `url`, and optional `apiKey`

### Provider Refactoring

**`src/provider.ts`**
- `getEndpoints()` now returns array of endpoints instead of single URL
- Automatically migrates legacy `lemonade.serverUrl` + `lemonade.apiKey` secrets to new format on first access
- `prepareLanguageModelChatInformation()` fans out to all endpoints concurrently, swallowing individual failures
- Model IDs prefixed with `<shortname>/<modelId>` to distinguish endpoints
- Request routing decodes `<shortname>` from selected model ID to route to correct endpoint

### New UI for Endpoint Management

**`src/extension.ts`**
- `lemonade.manage` command now opens quick pick showing all endpoints
- Add/Edit/Remove endpoints via interactive flow with validation
- Stores endpoints as JSON in `lemonade.endpoints` secret

### Comprehensive Tests

**`src/test/provider.test.ts`**
- Default endpoint fallback when none configured
- Migration test for legacy secrets
- Multiple endpoints reading
- Model ID prefixing verification

## Backward Compatibility

The extension remains fully backward compatible — existing users with single-server config will be automatically migrated to the new multi-endpoint format on first access.