### PR TITLE
Lemonade now defaults to port 13305 so use that

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can now start chatting with your local LLM models! 🥳
 
 
 ## 🔧 Configuration
-The extension connects to `http://localhost:8000/api/v1` by default. You can change this by:
+The extension connects to `http://localhost:13305/api/v1` by default. You can change this by:
 1. Opening VS Code Command Palette (Ctrl+Shift+P)
 2. Running "Manage Lemonade Provider" command
 3. Entering your custom Lemonade server URL

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("lemonade.manage", async () => {
 			const existingUrl = await context.secrets.get("lemonade.serverUrl");
 			const existingApiKey = await context.secrets.get("lemonade.apiKey");
-			const defaultUrl = "http://localhost:8000/api/v1";
+			const defaultUrl = "http://localhost:13305/api/v1";
 
 			// Step 1: Server URL configuration
 			const serverUrl = await vscode.window.showInputBox({

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,7 +12,7 @@ import {
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
 import type { LemonadeModel, LemonadeModelsResponse } from "./types";
 
-const DEFAULT_BASE_URL = "http://localhost:8000/api/v1";
+const DEFAULT_BASE_URL = "http://localhost:13305/api/v1";
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_API_KEY = "lemonade";


### PR DESCRIPTION
Since version 10 Lemonade server is now sitting on port 13305 but this extension defaults to the old 8000.
This PR changes that so the extension should find Lemonade by default.