### PR TITLE
refactor(provider): enable maxInputTokens to be set by context length on Lemonade Server

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -130,7 +130,7 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 			tooltip: "Lemonade Local LLM",
 			family: "lemonade",
 			version: "1.0.0",
-			maxInputTokens: maxInput,
+			maxInputTokens: model?.recipe_options?.ctx_size ?? maxInput,
 			maxOutputTokens: maxOutput,
 			capabilities: {
 				toolCalling: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,6 @@ export interface OpenAIChatMessage {
 	tool_call_id?: string;
 }
 
-
 /**
  * Buffer used to accumulate streamed tool call parts until arguments are valid JSON.
  */
@@ -44,6 +43,9 @@ export interface LemonadeModel {
 	object: string;
 	created?: number;
 	owned_by?: string;
+	recipe_options?: {
+		ctx_size?: number;
+	};
 }
 
 /**


### PR DESCRIPTION
Sorry, new here to using Lemonade server. I'm not 100% sure if this is valid, or if it's just my setting. When I set my context explicitly on Lemonade Server, it's returned something like this from the models endpoint:

```json
{
  "data": [
    {
      "checkpoint": "unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
      "checkpoints": {
        "main": "unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
        "mmproj": "unsloth/Qwen3.6-35B-A3B-GGUF:mmproj-F16.gguf"
      },
      "created": 1234567890,
      "id": "Qwen3.6-35B-A3B-GGUF",
      "labels": [
        "vision",
        "tool-calling",
        "hot"
      ],
      "object": "model",
      "owned_by": "lemonade",
      "recipe": "llamacpp",
      "recipe_options": {
        "ctx_size": 200000
      },
      "size": 22.4,
      "suggested": true
    },
  ],
  "object": "list"
}
```
_I removed some fields in the sample_

So I thought why not at least attempt to pull in the allowable input tokens rather than having to set one single value, then used for all models, through an env setting.

Also, judging by the object returned, it looked like you should also be able to update the `imageInput` field using the labels. However, when I manually set it to true, the model didn't seem to make any use of it, so I haven't touched that.