### PR TITLE
Ephemeral Data Filter Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
 			{
 				"command": "lemonade.manage",
 				"title": "Manage Lemonade Provider"
+			},
+			{
+				"command": "lemonade.toggleEphemeralFilter",
+				"title": "Toggle Lemonade filter ephemeral data"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,31 @@ export function activate(context: vscode.ExtensionContext) {
 			await manageEndpoints(context.secrets, provider);
 		})
 	);
+
+	// Toggle ephemeral data filter command
+	context.subscriptions.push(
+		vscode.commands.registerCommand("lemonade.toggleEphemeralFilter", async () => {
+			const currentSetting = await context.secrets.get("lemonade.filterEphemeralData");
+			const currentStatus = currentSetting === "true" ? "enabled" : currentSetting === "false" ? "disabled" : "default (enabled)";
+
+			const choice = await vscode.window.showQuickPick(
+				[
+					{ label: "Enable", description: "Filter out ephemeral data (recommended)" },
+					{ label: "Disable", description: "Do not filter ephemeral data (for debugging)" },
+					{ label: "Cancel", description: "Abort without changing settings" }
+				],
+				{ placeHolder: `Current state: ${currentStatus}. Select an option:` }
+			);
+
+			if (choice === undefined || choice.label === "Cancel") {
+				return;
+			}
+
+			const newValue = choice.label === "Enable" ? "true" : "false";
+			await context.secrets.store("lemonade.filterEphemeralData", newValue);
+			vscode.window.showInformationMessage(`Lemonade ephemeral data filter ${choice.label.toLowerCase()}d.`);
+		})
+	);
 }
 
 export function deactivate() {}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -280,7 +280,11 @@ export class LemonadeChatModelProvider implements LanguageModelChatProvider {
 			const baseUrl = endpoint.url;
 			const apiKey = endpoint.apiKey || DEFAULT_API_KEY;
 
-            const openaiMessages = convertMessages(messages);
+			// Check if ephemeral data filtering is enabled (default: true)
+			const filterEphemeralSetting = await this.secrets.get("lemonade.filterEphemeralData");
+			const filterEphemeral = filterEphemeralSetting !== "false";
+
+            const openaiMessages = convertMessages(messages, filterEphemeral);
 
 			validateRequest(messages);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -345,18 +345,23 @@ function collectToolResultText(
 			const mimeType = isObj ? (c as { mimeType?: unknown }).mimeType : undefined;
 
 			if (filterEphemeral && mimeType === "cache_control") {
-				// Silently drop the sentinel to prevent it from leaking into tool output
+				// Silently drop the cache_control sentinel to prevent it from leaking into tool output
 				continue;
 			}
 
-			// For non-filtering mode or unknown parts, warn but don't serialize
-			const ctor = isObj
-				? (Object.getPrototypeOf(c as object) as { constructor?: { name?: string } } | undefined)
-					?.constructor?.name
-				: undefined;
-			console.warn(
-				`[Lemonade Model Provider] dropped unknown tool-result part: ctor=${ctor ?? typeof c} mimeType=${String(mimeType)}`
-			);
+			// For all other cases, use the original behavior: serialize to JSON
+			try {
+				text += JSON.stringify(c);
+			} catch {
+				// If serialization fails, warn but don't crash
+				const ctor = isObj
+					? (Object.getPrototypeOf(c as object) as { constructor?: { name?: string } } | undefined)
+						?.constructor?.name
+					: undefined;
+				console.warn(
+					`[Lemonade Model Provider] failed to serialize tool-result part: ctor=${ctor ?? typeof c} mimeType=${String(mimeType)}`
+				);
+			}
 		}
 	}
 	return text;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,9 +138,13 @@ function sanitizeSchema(input: unknown, propName?: string): Record<string, unkno
 /**
  * Convert VS Code chat request messages into OpenAI-compatible message objects.
  * @param messages The VS Code chat messages to convert.
+ * @param filterEphemeral Whether to filter out ephemeral data sentinels.
  * @returns OpenAI-compatible messages array.
  */
-export function convertMessages(messages: readonly vscode.LanguageModelChatRequestMessage[]): OpenAIChatMessage[] {
+export function convertMessages(
+	messages: readonly vscode.LanguageModelChatRequestMessage[],
+	filterEphemeral: boolean = true
+): OpenAIChatMessage[] {
 	const out: OpenAIChatMessage[] = [];
 	for (const m of messages) {
 		const role = mapRole(m);
@@ -162,7 +166,7 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
 				toolCalls.push({ id, type: "function", function: { name: part.name, arguments: args } });
 			} else if (isToolResultPart(part)) {
 				const callId = (part as { callId?: string }).callId ?? "";
-				const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
+				const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> }, filterEphemeral);
 				toolResults.push({ callId, content });
 			}
 		}
@@ -323,8 +327,12 @@ function mapRole(message: vscode.LanguageModelChatRequestMessage): Exclude<OpenA
 /**
  * Concatenate tool result content into a single text string.
  * @param pr Tool result-like object with content array.
+ * @param filterEphemeral Whether to filter out ephemeral data sentinels.
  */
-function collectToolResultText(pr: { content?: ReadonlyArray<unknown> }): string {
+function collectToolResultText(
+	pr: { content?: ReadonlyArray<unknown> },
+	filterEphemeral: boolean = true
+): string {
 	let text = "";
 	for (const c of pr.content ?? []) {
 		if (c instanceof vscode.LanguageModelTextPart) {
@@ -332,11 +340,23 @@ function collectToolResultText(pr: { content?: ReadonlyArray<unknown> }): string
 		} else if (typeof c === "string") {
 			text += c;
 		} else {
-			try {
-				text += JSON.stringify(c);
-			} catch {
-				/* ignore */
+			// Check for cache_control sentinel (VS Code 1.118+ internal sentinel)
+			const isObj = !!c && typeof c === "object";
+			const mimeType = isObj ? (c as { mimeType?: unknown }).mimeType : undefined;
+
+			if (filterEphemeral && mimeType === "cache_control") {
+				// Silently drop the sentinel to prevent it from leaking into tool output
+				continue;
 			}
+
+			// For non-filtering mode or unknown parts, warn but don't serialize
+			const ctor = isObj
+				? (Object.getPrototypeOf(c as object) as { constructor?: { name?: string } } | undefined)
+					?.constructor?.name
+				: undefined;
+			console.warn(
+				`[Lemonade Model Provider] dropped unknown tool-result part: ctor=${ctor ?? typeof c} mimeType=${String(mimeType)}`
+			);
 		}
 	}
 	return text;


### PR DESCRIPTION
# Ephemeral Data Filter Implementation

## Problem Summary

VS Code 1.118+ injects an internal `LanguageModelDataPart` sentinel with `mimeType: "cache_control"` and `data: "ephemeral"` at the end of tool-result turns. The matching `CustomDataPartMimeTypes` enum is not exported in the public VS Code API, so BYOK extensions cannot identify it through stable API. The current `collectToolResultText` function in `src/utils.ts` uses `JSON.stringify(c)` as a fallback, which serializes this sentinel into the tool output, producing `{"$mid":24,"mimeType":"cache_control","data":"ZXBoZW1lcmFs"}` that leaks into the upstream provider's request body.

### References
- [microsoft/vscode#313920](https://github.com/microsoft/vscode/issues/313920) - BYOK chat providers receive an internal cache_control LanguageModelDataPart sentinel that's not in the public API
- [Laurent00TT/deepseek-v4-vscode-chat#12](https://github.com/Laurent00TT/deepseek-v4-vscode-chat/pull/12) - Similar fix for deepseek-v4-vscode-chat

## Why This Matters for BYOK

- **Pollutes the upstream prompt-cache prefix**: A leaked `{"$mid":24,...}` substring on one turn changes the byte-exact prefix and misses every subsequent turn's cache — defeating the whole point of the sentinel.
- **Wastes input tokens**: At the upstream model on a marshalled envelope it cannot act on.
- **No documented API to defend against it**: Extensions today must either string-match the literal mime type `"cache_control"` (private API surface) or skip every `LanguageModelDataPart` they don't recognize as an image — both fragile.
- **Models detect it as corruption**: This leads to circular tool calls, and attempts to repair, or remove the non-existent metadata from files; and generally spinning the agent/model off task.

## Implementation Plan

### Overview

Implement a filter for the ephemeral data sentinel that can be toggled via a menu-driven prompt, similar to the existing "Manage Lemonade Provider" option.

### Changes Required

#### 1. Update `collectToolResultText` in `src/utils.ts`

**Current behavior:**
```typescript
function collectToolResultText(pr: { content?: ReadonlyArray<unknown> }): string {
    let text = "";
    for (const c of pr.content ?? []) {
        if (c instanceof vscode.LanguageModelTextPart) {
            text += c.value;
        } else if (typeof c === "string") {
            text += c;
        } else {
            try {
                text += JSON.stringify(c);
            } catch {
                /* ignore */
            }
        }
    }
    return text;
}
```

**Problem:** The `JSON.stringify(c)` fallback serializes the internal sentinel into tool output.

**Proposed fix:**
- Whitelist only `LanguageModelTextPart` and raw strings
- Filter out parts with `mimeType === "cache_control"` (the sentinel)
- Add warning mechanism for novel non-text parts (quiet on the known sentinel)

#### 2. Add Configuration Toggle in `src/extension.ts`

Add a new command `lemonade.toggleEphemeralFilter` that:
- Stores the filter preference in `SecretStorage` (key: `lemonade.filterEphemeralData`)
- Implements a menu-driven prompt with options:
  - `Enable`: Turn on filtering (recommended)
  - `Disable`: Turn off filtering (for debugging)
  - `Cancel`: Abort without changing settings
- Shows the current state before prompting

#### 3. Update `package.json`

Add the new command contribution:
```json
{
    "command": "lemonade.toggleEphemeralFilter",
    "title": "Toggle Lemonade filter ephemeral data"
}
```

#### 4. Modify `collectToolResultText` to respect the toggle

Read the filter preference from `SecretStorage`:
- When enabled, filter out the `cache_control` sentinel
- When disabled, use the current behavior (with warning) for debugging

### Files to Modify

1. **`src/utils.ts`**
   - Modify `collectToolResultText` function to filter out ephemeral data

2. **`src/extension.ts`**
   - Add new command registration for `lemonade.toggleEphemeralFilter`
   - Implement the toggle function with menu-driven prompt

3. **`package.json`**
   - Add command contribution for the new toggle

## Implementation Details

### `src/utils.ts` - Modified `collectToolResultText`

```typescript
/**
 * Concatenate tool result content into a single text string.
 * @param pr Tool result-like object with content array.
 * @param filterEphemeral Whether to filter out ephemeral data sentinels.
 */
function collectToolResultText(
    pr: { content?: ReadonlyArray<unknown> },
    filterEphemeral: boolean = true
): string {
    let text = "";
    for (const c of pr.content ?? []) {
        if (c instanceof vscode.LanguageModelTextPart) {
            text += c.value;
        } else if (typeof c === "string") {
            text += c;
        } else {
            // Check for cache_control sentinel (VS Code 1.118+ internal sentinel)
            const isObj = !!c && typeof c === "object";
            const mimeType = isObj ? (c as { mimeType?: unknown }).mimeType : undefined;
            
            if (filterEphemeral && mimeType === "cache_control") {
                // Silently drop the sentinel to prevent it from leaking into tool output
                continue;
            }
            
            // For non-filtering mode or unknown parts, warn but don't serialize
            const ctor = isObj
                ? (Object.getPrototypeOf(c as object) as { constructor?: { name?: string } } | undefined)
                    ?.constructor?.name
                : undefined;
            console.warn(
                `[Lemonade Model Provider] dropped unknown tool-result part: ctor=${ctor ?? typeof c} mimeType=${String(mimeType)}`
            );
        }
    }
    return text;
}
```

### `src/extension.ts` - New Command

```typescript
context.subscriptions.push(
    vscode.commands.registerCommand("lemonade.toggleEphemeralFilter", async () => {
        const currentSetting = await context.secrets.get("lemonade.filterEphemeralData");
        const currentStatus = currentSetting === "true" ? "enabled" : currentSetting === "false" ? "disabled" : "default (enabled)";
        
        const choice = await vscode.window.showQuickPick(
            [
                { label: "Enable", description: "Filter out ephemeral data (recommended)" },
                { label: "Disable", description: "Do not filter ephemeral data (for debugging)" },
                { label: "Cancel", description: "Abort without changing settings" }
            ],
            { placeHolder: `Current state: ${currentStatus}. Select an option:` }
        );
        
        if (choice === undefined || choice.label === "Cancel") {
            return;
        }
        
        const newValue = choice.label === "Enable" ? "true" : "false";
        await context.secrets.store("lemonade.filterEphemeralData", newValue);
        vscode.window.showInformationMessage(`Lemonade ephemeral data filter ${choice.label.toLowerCase()}d.`);
    })
);
```

### `package.json` - Command Contribution

```json
{
    "contributes": {
        "commands": [
            {
                "command": "lemonade.toggleEphemeralFilter",
                "title": "Toggle Lemonade filter ephemeral data"
            }
        ]
    }
}
```

## Testing

1. **Verify the filter works correctly with tool results:**
   - Run a tool that returns text (e.g., built-in `read_file`)
   - Confirm no `{"$mid":24,"mimeType":"cache_control","data":"ZXBoZW1lcmFs"}` appears in tool output

2. **Ensure the toggle can be enabled/disabled via command palette:**
   - Open Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`)
   - Run "Toggle Lemonade filter ephemeral data"
   - Verify options appear and can be selected

3. **Confirm the current state is displayed correctly:**
   - The quick pick should show the current state before prompting
   - Enable/disable should update the state correctly

## Benefits

- Prevents `{"$mid":24,"mimeType":"cache_control","data":"ZXBoZW1lcmFs"}` from leaking into chat content
- Maintains backward compatibility through the toggle
- Provides visibility into novel parts through warnings
- Follows the same pattern as the referenced deepseek-v4-vscode-chat fix

## Future Considerations

- Once VS Code exports `CustomDataPartMimeTypes`, update to use the stable API
- Consider adding similar filters for other potential sentinels (`StatefulMarker`, `ThinkingData`, `ContextManagement`)

## References

- [microsoft/vscode#313920](https://github.com/microsoft/vscode/issues/313920)
- [Laurent00TT/deepseek-v4-vscode-chat#12](https://github.com/Laurent00TT/deepseek-v4-vscode-chat/pull/12)
- [Laurent00TT/deepseek-v4-vscode-chat#11](https://github.com/Laurent00TT/deepseek-v4-vscode-chat/issues/11)
