### PR TITLE
Fix extension source URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"icon": "assets/logo.png",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/lemonade-sdk/lemonade"
+		"url": "https://github.com/lemonade-sdk/lemonade-vscode"
 	},
 	"version": "0.0.8",
 	"engines": {


### PR DESCRIPTION
When I look at the metadata for this extension, I expect to see the source code of this extension not the source of the server - just like an extension for working with docker files should link to its source, not the source code for docker itself.

<img width="1114" height="964" alt="image" src="https://github.com/user-attachments/assets/8af383fc-3278-4bfd-8b1c-019aa6d273a3" />
